### PR TITLE
fix: correct hamburger menu z-index to show below side menu

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2634,7 +2634,7 @@ body {
         left: 0;
         bottom: 0;
         width: 260px;
-        z-index: 900;
+        z-index: 1100;
         transform: translateX(-100%);
         transition: transform 0.3s ease;
         overflow-y: auto;
@@ -2654,7 +2654,7 @@ body {
         right: 0;
         bottom: 0;
         background: rgba(0, 0, 0, 0.5);
-        z-index: 899;
+        z-index: 1050;
     }
 
     /* Encounter sidebar as fixed drawer too */
@@ -2664,7 +2664,7 @@ body {
         left: 0;
         bottom: 0;
         width: 260px;
-        z-index: 900;
+        z-index: 1100;
         transform: translateX(-100%);
         transition: transform 0.3s ease;
         background: var(--bg-secondary);


### PR DESCRIPTION
## Summary
- Fixed the hamburger menu appearing above the side menu on mobile viewports (<=768px)
- The root cause was a z-index stacking issue: the hamburger button had `z-index: 1000` while both `.sidebar` and `.encounter-sidebar` only had `z-index: 900`, and the backdrop had `z-index: 899`
- Raised sidebar/encounter-sidebar z-index to `1100` and backdrop to `1050`, establishing the correct layering: hamburger (1000) < backdrop (1050) < sidebar (1100)

Fixes #1

## Test plan
- [ ] Open the app in a browser at <=768px viewport width (or use mobile device emulation)
- [ ] Tap the hamburger button to open the side menu
- [ ] Verify the side menu slides in and fully covers the hamburger button
- [ ] Verify the semi-transparent backdrop appears behind the sidebar but above page content
- [ ] Tap the backdrop to close the menu and verify the hamburger button is visible again
- [ ] Switch to the Encounter Builder tab and repeat the above steps to verify the encounter sidebar also displays above the hamburger
- [ ] Verify desktop layout (>768px) is unaffected since the hamburger is hidden and sidebar z-index only applies within the media query

🤖 Generated with [Claude Code](https://claude.com/claude-code)